### PR TITLE
Add LCM function to math directory

### DIFF
--- a/src/main/kotlin/math/LCM.kt
+++ b/src/main/kotlin/math/LCM.kt
@@ -1,0 +1,23 @@
+/**
+ * Computes the Least Common Multiple (LCM) of two integers.
+ */
+fun lcm(a: Int, b: Int): Int {
+    return kotlin.math.abs(a * b) / gcd(a, b)
+}
+
+// Reusing gcd function from GCD.kt
+fun gcd(a: Int, b: Int): Int {
+    var x = a
+    var y = b
+    while (y != 0) {
+        val temp = y
+        y = x % y
+        x = temp
+    }
+    return kotlin.math.abs(x)
+}
+
+fun main() {
+    println("LCM of 12 and 18 is ${lcm(12, 18)}") // 36
+    println("LCM of 5 and 7 is ${lcm(5, 7)}")     // 35
+}


### PR DESCRIPTION
This PR adds a function to compute the Least Common Multiple (LCM) of two integers in Kotlin. It uses the previously defined GCD function for calculation. A main() function is included to show example usage.